### PR TITLE
fix param in update event status to event status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/scheduler",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/storage/events_database_client.ts
+++ b/src/storage/events_database_client.ts
@@ -1,12 +1,12 @@
 import { BaseDatabaseClient } from '@/storage/base_database_client';
-import { Event } from '@/models/events';
+import { Event, EventStatus } from '@/models/events';
 
 interface EventsDatabaseClient extends BaseDatabaseClient {
     getEventsByProvider(providerId: string): Promise<Event[]>;
     getEventsByCustomer(customerId: string): Promise<Event[]>;
     getEventByProviderOrCustomer(userId: string): Promise<Event[]>;
     createEvent(event: Event): Promise<Event>;
-    updateEventStatus(eventId: string, status: string, customerId?: string, color?: string): Promise<Event>;
+    updateEventStatus(eventId: string, status: EventStatus, customerId?: string, color?: string): Promise<Event>;
     deleteEvent(eventId: string): Promise<void>;
 };
 


### PR DESCRIPTION
This pull request includes updates to the package version and improvements to type safety in the `updateEventStatus` method of the `EventsDatabaseClient` interface. Below are the most important changes:

### Version Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.1` to `0.0.2` to reflect the new changes in the library.

### Type Safety Improvements:

* [`src/storage/events_database_client.ts`](diffhunk://#diff-7c6e12939daae78390b5dcbd5a042b37b66eb4cd4f9d1ee8fba87250955f02c9L2-R9): Enhanced the `updateEventStatus` method by replacing the `status` parameter type from `string` to the more specific `EventStatus` type, improving type safety and reducing the likelihood of invalid status values.