### PR TITLE
refactor: change deleteEvent to return Event | null

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/scheduler",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -43,7 +43,7 @@ const updateEventStatus = async (eventId: string, status: EventStatus, customerI
     return await getDatabaseClient()!.updateEventStatus(eventId, status, color, customerId);
 };
 
-const deleteEvent = async (eventId: string): Promise<void> => {
+const deleteEvent = async (eventId: string): Promise<Event | null> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }

--- a/src/storage/events_database_client.ts
+++ b/src/storage/events_database_client.ts
@@ -8,7 +8,7 @@ interface EventsDatabaseClient extends BaseDatabaseClient {
     getEventsByProviderOrCustomer(userId: string): Promise<Event[]>;
     createEvent(event: Event): Promise<Event>;
     updateEventStatus(eventId: string, status: EventStatus, customerId?: string, color?: string): Promise<Event>;
-    deleteEvent(eventId: string): Promise<void>;
+    deleteEvent(eventId: string): Promise<Event | null>;
 };
 
 export {

--- a/src/storage/events_postgres_client.ts
+++ b/src/storage/events_postgres_client.ts
@@ -79,8 +79,16 @@ class EventsPostgresClient extends BasePostgresClient implements EventsDatabaseC
         return mapToEvent(result.rows[0]);
     }
 
-    async deleteEvent(eventId: string): Promise<void> {
-        await this.query(DELETE_EVENT_QUERY, [eventId]);
+    async deleteEvent(eventId: string): Promise<Event | null> {
+        const result = await this.query(DELETE_EVENT_QUERY, [eventId]);
+        
+        // If no rows were affected, event didn't exist
+        if (result.rows.length === 0) {
+            return null;
+        }
+        
+        // Return the deleted event
+        return mapToEvent(result.rows[0]);
     }
 }
 

--- a/src/storage/queries.ts
+++ b/src/storage/queries.ts
@@ -72,7 +72,8 @@ const UPDATE_EVENT_STATUS_QUERY =
 
 const DELETE_EVENT_QUERY =
     `DELETE FROM scheduler_events 
-     WHERE event_id = $1`;
+     WHERE event_id = $1
+     RETURNING event_id, title, summary, start_time, end_time, color, status, provider_id, customer_id`;
 
 export {
     CREATE_VERSION_TABLE_QUERY,


### PR DESCRIPTION
This pull request introduces changes to enhance functionality and consistency in the event deletion process and updates the package version. The most significant updates include modifying the `deleteEvent` method to return the deleted event or `null` if the event doesn't exist, and updating the `DELETE_EVENT_QUERY` to return event details upon deletion.

### Event Deletion Enhancements:
- **`src/api/events.ts`:** Updated the `deleteEvent` function to return an `Event | null` instead of `void`, ensuring the caller can handle cases where the event doesn't exist.
- **`src/storage/events_database_client.ts`:** Modified the `deleteEvent` method signature in the `EventsDatabaseClient` interface to reflect the new return type (`Event | null`).
- **`src/storage/events_postgres_client.ts`:** Updated the `deleteEvent` implementation in `EventsPostgresClient` to return the deleted event's details or `null` if no rows are affected.
- **`src/storage/queries.ts`:** Enhanced the `DELETE_EVENT_QUERY` to include a `RETURNING` clause, allowing the database to return the deleted event's details.

### Package Version Update:
- **`package.json`:** Incremented the package version from `0.0.3` to `0.0.4` to reflect the new changes.