### PR TITLE
update customerId to string | null for update status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/scheduler",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A TypeScript library for LLM clients",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -50,14 +50,14 @@ const updateEventStatusAndColor = async (eventId: string, status: EventStatus, c
     return await getDatabaseClient()!.updateEventStatusAndColor(eventId, status, color);
 };
 
-const updateEventStatusAndCustomerId = async (eventId: string, status: EventStatus, customerId: string): Promise<Event> => {
+const updateEventStatusAndCustomerId = async (eventId: string, status: EventStatus, customerId: string | null): Promise<Event> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }
     return await getDatabaseClient()!.updateEventStatusAndCustomerId(eventId, status, customerId);
 };
 
-const updateEventStatusWithColorAndCustomerId = async (eventId: string, status: EventStatus, color: string, customerId: string): Promise<Event> => {
+const updateEventStatusWithColorAndCustomerId = async (eventId: string, status: EventStatus, color: string, customerId: string | null): Promise<Event> => {
     if (!isDatabaseClientSet()) {
         throw new Error("Database client not initialized. Call initializeDatabase first.");
     }

--- a/src/storage/events_database_client.ts
+++ b/src/storage/events_database_client.ts
@@ -1,6 +1,5 @@
 import { BaseDatabaseClient } from '@/storage/base_database_client';
 import { Event, EventStatus } from '@/models/events';
-import { Nullable } from 'vitest';
 
 interface EventsDatabaseClient extends BaseDatabaseClient {
     getEventById(eventId: string): Promise<Event | null>;

--- a/src/storage/events_database_client.ts
+++ b/src/storage/events_database_client.ts
@@ -1,5 +1,6 @@
 import { BaseDatabaseClient } from '@/storage/base_database_client';
 import { Event, EventStatus } from '@/models/events';
+import { Nullable } from 'vitest';
 
 interface EventsDatabaseClient extends BaseDatabaseClient {
     getEventById(eventId: string): Promise<Event | null>;
@@ -8,9 +9,9 @@ interface EventsDatabaseClient extends BaseDatabaseClient {
     getEventsByProviderOrCustomer(userId: string): Promise<Event[]>;
     createEvent(event: Event): Promise<Event>;
     updateEventStatus(eventId: string, status: EventStatus): Promise<Event>;
-    updateEventStatusAndCustomerId(eventId: string, status: EventStatus, customerId: string): Promise<Event>;
+    updateEventStatusAndCustomerId(eventId: string, status: EventStatus, customerId: string | null): Promise<Event>;
     updateEventStatusAndColor(eventId: string, status: EventStatus, color: string): Promise<Event>;
-    updateEventStatusWithColorAndCustomerId(eventId: string, status: EventStatus, color: string, customerId: string): Promise<Event>;
+    updateEventStatusWithColorAndCustomerId(eventId: string, status: EventStatus, color: string, customerId: string | null): Promise<Event>;
     deleteEvent(eventId: string): Promise<Event | null>;
 };
 

--- a/src/storage/events_postgres_client.ts
+++ b/src/storage/events_postgres_client.ts
@@ -89,7 +89,7 @@ class EventsPostgresClient extends BasePostgresClient implements EventsDatabaseC
         return mapToEvent(result.rows[0]);
     }
 
-    async updateEventStatusAndCustomerId(eventId: string, status: EventStatus, customerId: string): Promise<Event> {
+    async updateEventStatusAndCustomerId(eventId: string, status: EventStatus, customerId: string | null): Promise<Event> {
         const result = await this.query(UPDATE_EVENT_STATUS_AND_CUSTOMER_ID_QUERY, [
             eventId,
             status,
@@ -98,7 +98,7 @@ class EventsPostgresClient extends BasePostgresClient implements EventsDatabaseC
         return mapToEvent(result.rows[0]);
     }
 
-    async updateEventStatusWithColorAndCustomerId(eventId: string, status: EventStatus, color: string, customerId: string): Promise<Event> {
+    async updateEventStatusWithColorAndCustomerId(eventId: string, status: EventStatus, color: string, customerId: string | null): Promise<Event> {
         const result = await this.query(UPDATE_EVENT_STATUS_COLOR_AND_CUSTOMER_ID_QUERY, [
             eventId,
             status,


### PR DESCRIPTION
This pull request includes a version bump for the `@innobridge/scheduler` package and updates to the event management logic to support `null` values for the `customerId` parameter. These changes improve flexibility in handling events and align the codebase with nullable customer IDs.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.0.5` to `0.0.6`.

### Event Management Enhancements:
* [`src/api/events.ts`](diffhunk://#diff-7a137c657c197ae9a164fff96b6a94688f7fec5803cb1119ccebabda9f3b0db9L53-R60): Modified the `updateEventStatusAndCustomerId` and `updateEventStatusWithColorAndCustomerId` functions to allow `customerId` to be `null`.
* [`src/storage/events_database_client.ts`](diffhunk://#diff-7c6e12939daae78390b5dcbd5a042b37b66eb4cd4f9d1ee8fba87250955f02c9L11-R14): Updated the `EventsDatabaseClient` interface to reflect the nullable `customerId` in the `updateEventStatusAndCustomerId` and `updateEventStatusWithColorAndCustomerId` methods.
* [`src/storage/events_postgres_client.ts`](diffhunk://#diff-b90d05b9e9793937a54d4e5ecaf33d199d842795511d98658a9c4f03e3c893f9L92-R92): Adjusted the `updateEventStatusAndCustomerId` and `updateEventStatusWithColorAndCustomerId` methods in the `EventsPostgresClient` class to handle `customerId` as `null`. [[1]](diffhunk://#diff-b90d05b9e9793937a54d4e5ecaf33d199d842795511d98658a9c4f03e3c893f9L92-R92) [[2]](diffhunk://#diff-b90d05b9e9793937a54d4e5ecaf33d199d842795511d98658a9c4f03e3c893f9L101-R101)

### Dependency Update:
* [`src/storage/events_database_client.ts`](diffhunk://#diff-7c6e12939daae78390b5dcbd5a042b37b66eb4cd4f9d1ee8fba87250955f02c9R3): Added an import for `Nullable` from `vitest`, though it is not directly used in the changes.